### PR TITLE
Improve memory management

### DIFF
--- a/include/ssalloc.h
+++ b/include/ssalloc.h
@@ -28,12 +28,13 @@
 #else
 #  define SSALLOC_SIZE (1024 * 1024 * 1024)
 #endif
+#define SSALLOC_SIZE_ALL (size_t)((size_t)10 * (size_t)1024 * (size_t)1024 * (size_t)1024)
 
 /* extern const size_t ssalloc_size_alloc[SSALLOC_NUM_ALLOCATORS]; */
 
 
 void ssalloc_set(void* mem);
-void ssalloc_init();
+void ssalloc_init(int number_of_threads);
 void ssalloc_align();
 void ssalloc_align_alloc(unsigned int allocator);
 void ssalloc_offset(size_t size);

--- a/sssp.c
+++ b/sssp.c
@@ -13,6 +13,9 @@
 #include "linden.h"
 //#include "gc/ptst.h"
 
+// Needed for ssalloc
+int number_of_threads;
+
 //#define STATIC
 #define MAX_DEPS 10
 #define MAX_NODES 9000000
@@ -121,7 +124,7 @@ void* sssp(void *data) {
   /* Create transaction */
   set_cpu(the_cores[d->id]);
   /* Wait on barrier */
-  ssalloc_init();
+  ssalloc_init(number_of_threads);
   PF_CORRECTION;
 
   seeds = seed_rand();
@@ -231,8 +234,6 @@ void catcher(int sig)
 int main(int argc, char **argv)
 {
   set_cpu(the_cores[0]);
-  ssalloc_init();
-  seeds = seed_rand();
   pin(pthread_self(), 0);
 
 #ifdef PAPI
@@ -378,6 +379,12 @@ int main(int argc, char **argv)
 
   assert(nb_threads > 0);
 
+  number_of_threads = nb_threads;
+
+  ssalloc_init(number_of_threads);
+
+  seeds = seed_rand();
+  
   if (seed == 0)
     srand((int)time(0));
   else

--- a/test.c
+++ b/test.c
@@ -26,6 +26,9 @@
 #include "linden.h"
 //#include "gc/ptst.h"
 
+// Needed for ssalloc
+int number_of_threads;
+
 #define MAX_DEPS 10
 
 //#define PAPI 1
@@ -121,7 +124,7 @@ void* test(void *data) {
   TM_THREAD_ENTER(d->id);
   set_cpu(the_cores[d->id]);
   /* Wait on barrier */
-  ssalloc_init();
+  ssalloc_init(number_of_threads);
   PF_CORRECTION;
 
   seeds = seed_rand();
@@ -347,8 +350,6 @@ void catcher(int sig)
 int main(int argc, char **argv)
 {
   set_cpu(the_cores[0]);
-  ssalloc_init();
-  seeds = seed_rand();
 
 #ifdef PAPI
   if (PAPI_VER_CURRENT != PAPI_library_init(PAPI_VER_CURRENT))
@@ -534,6 +535,11 @@ int main(int argc, char **argv)
   assert(range > 0);
   assert(update >= 0 && update <= 100);
 
+  number_of_threads = nb_threads;
+
+  ssalloc_init(number_of_threads);
+  seeds = seed_rand();
+  
   // if (range < initial)
   // {
   range = 100000000;


### PR DESCRIPTION
Without the patch it is only possible to specify how much memory each
thread that is using the SprayList will be able to allocate. This is
problematic for the single source shortest paths benchmark (bin/sssp)
as it makes it impossible to run the benchmark with a single thread
and many threads using the same binary. The benchmark would either run
out of memory when a single thread is used or there would not be
enough memory on the machine when many threads are used.

With the patch one can specify how much memory all threads that are
using the SprayList can allocated together (the #define
SSALLOC_SIZE_ALL in include/ssalloc.h). The patch makes sure that this
amount of memory is divided between the threads.